### PR TITLE
Release lock if fetchAndStore fail

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -151,6 +151,7 @@ func (c *Cache) getOrFetch(ctx context.Context, u string, forceRefresh bool) (in
 	// if forceRefresh is true)
 	if forceRefresh || !e.hasBeenFetched() {
 		if err := c.queue.fetchAndStore(ctx, e); err != nil {
+			e.releaseSem()
 			return nil, fmt.Errorf(`failed to fetch %q: %w`, u, err)
 		}
 	}


### PR DESCRIPTION
If there is a failure while doing a forceRefresh on the cache, it will never release the lock. This means that any following request to the cache will just hang as the call to e.acquireSem() will wait forever. 