### PR TITLE
Aquire semaphore when network will be accessed

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -144,19 +144,23 @@ func (c *Cache) getOrFetch(ctx context.Context, u string, forceRefresh bool) (in
 	}
 	c.mu.RUnlock()
 
-	// Only one goroutine may enter this section.
-	e.acquireSem()
-
 	// has this entry been fetched? (but ignore and do a fetch
 	// if forceRefresh is true)
 	if forceRefresh || !e.hasBeenFetched() {
-		if err := c.queue.fetchAndStore(ctx, e); err != nil {
-			e.releaseSem()
-			return nil, fmt.Errorf(`failed to fetch %q: %w`, u, err)
-		}
-	}
 
-	e.releaseSem()
+		// Only one goroutine may enter this section.
+		// redundant checks allow cached gets avoid the semaphore,
+		// which allows them to return cached data immediately
+		// if the upstream server is slow or not responding
+		e.acquireSem()
+		if forceRefresh || !e.hasBeenFetched() {
+			if err := c.queue.fetchAndStore(ctx, e); err != nil {
+				e.releaseSem()
+				return nil, fmt.Errorf(`failed to fetch %q: %w`, u, err)
+			}
+		}
+		e.releaseSem()
+	}
 
 	e.mu.RLock()
 	data := e.data

--- a/cache.go
+++ b/cache.go
@@ -147,7 +147,6 @@ func (c *Cache) getOrFetch(ctx context.Context, u string, forceRefresh bool) (in
 	// has this entry been fetched? (but ignore and do a fetch
 	// if forceRefresh is true)
 	if forceRefresh || !e.hasBeenFetched() {
-
 		// Only one goroutine may enter this section.
 		// redundant checks allow cached gets avoid the semaphore,
 		// which allows them to return cached data immediately

--- a/queue.go
+++ b/queue.go
@@ -318,12 +318,12 @@ func (q *queue) refreshLoop(ctx context.Context, errSink ErrSink) {
 }
 
 func (q *queue) fetchAndStore(ctx context.Context, e *entry) error {
+	now := time.Now()
+	// synchronously go fetch
+	res, err := q.fetch.fetch(ctx, e.request)
 	e.mu.Lock()
 	defer e.mu.Unlock()
-
-	// synchronously go fetch
-	e.lastFetch = time.Now()
-	res, err := q.fetch.fetch(ctx, e.request)
+	e.lastFetch = now
 	if err != nil {
 		// Even if the request failed, we need to queue the next fetch
 		q.enqueueNextFetch(nil, e)


### PR DESCRIPTION
Potential fix for https://github.com/lestrrat-go/httprc/issues/24 . The full fix required not just acquiring the semaphore in `cache.go` more guardedly, but also not locking the event in `queue.go` until after the network request is made.

From a concurrency standpoint, the change to `queue.go` is safe because:
* Event as a whole is not much used.
* Its use is guarded by semaphpore.
* `queue.go` still only uses it under mutex, except for the read on e.request

As a sanity check, I ran `go test -race -count=1 ./...` 100 times against this patch and the race detector did not find issues. The bug reproduction repo (https://github.com/natenjoy/httprc-cache-issue) contains instructions in how to run this patch against a minimal server setup.

I did see there is a `v2` branch, but I still opted to open this PR against the `main` branch since latest tagged jwx package still uses v1.0.4. I was hoping if this change (eventually) looks mergeable that you could pull it over to the `v2` branch.