### PR TITLE
Revert "Aquire semaphore when network will be accessed (#25)"

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -318,12 +318,12 @@ func (q *queue) refreshLoop(ctx context.Context, errSink ErrSink) {
 }
 
 func (q *queue) fetchAndStore(ctx context.Context, e *entry) error {
-	now := time.Now()
-	// synchronously go fetch
-	res, err := q.fetch.fetch(ctx, e.request)
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.lastFetch = now
+
+	// synchronously go fetch
+	e.lastFetch = time.Now()
+	res, err := q.fetch.fetch(ctx, e.request)
 	if err != nil {
 		// Even if the request failed, we need to queue the next fetch
 		q.enqueueNextFetch(nil, e)


### PR DESCRIPTION
This reverts commit e73952d36956bff91fafef33e771a66d9360e81a. Looks like this optimization wasn't safe and caused issues with the reused request pointer being shared, which ended up in a scenario where the channel could be closed and then sent on. Thanks for pointing this out, @TheJokr .

Likely to fix https://github.com/lestrrat-go/httprc/issues/30