### PR TITLE
fix: back off on fetch failure instead of tight-looping

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -232,6 +232,10 @@ func (r *ResourceBase[T]) Sync(ctx context.Context) error {
 	traceSink.Put(ctx, fmt.Sprintf("httprc.Resource.Sync: fetching %q", r.u))
 	res, err := httpcl.Do(req)
 	if err != nil {
+		// Schedule retry after MinInterval so that connection failures
+		// don't cause a tight retry loop (the resource's Next stays at
+		// epoch if we don't update it here).
+		r.SetNext(time.Now().Add(r.MinInterval()))
 		return fmt.Errorf(`httprc.Resource.Sync: failed to execute HTTP request: %w`, err)
 	}
 	defer res.Body.Close()

--- a/resource_test.go
+++ b/resource_test.go
@@ -254,6 +254,29 @@ func TestResourceErrorHandling(t *testing.T) {
 		require.Error(t, resource.Ready(readyCtx), "network error resource should not become ready")
 	})
 
+	t.Run("network error backs off instead of tight-looping", func(t *testing.T) {
+		minInterval := 2 * time.Second
+		resource, err := httprc.NewResource[[]byte](
+			"http://127.0.0.1:1/unreachable",
+			httprc.BytesTransformer(),
+			httprc.WithMinInterval(minInterval),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.Add(ctx, resource, httprc.WithWaitReady(false)))
+
+		// Wait for the first fetch attempt to fail
+		readyCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		require.Error(t, resource.Ready(readyCtx))
+
+		// After a failed fetch, Next should be pushed forward by at least
+		// MinInterval, not stuck at epoch (which caused a tight retry loop).
+		next := resource.Next()
+		require.True(t, next.After(time.Now().Add(minInterval/2)),
+			"after connection failure, Next should be at least minInterval/2 in the future, got %v", next)
+	})
+
 	t.Run("context cancellation", func(t *testing.T) {
 		slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(2 * time.Second) // Slow response


### PR DESCRIPTION
## Summary

When `Sync()` fails at the HTTP request level (connection refused, DNS failure, timeout), `Next` was left at its initial value (epoch), causing the backend to re-dispatch the resource every ~1 second in a tight retry loop.

This patch sets `Next` to `now + MinInterval` on the error path, so failed resources back off before retrying.

Fixes #119

## What changed

- **`resource.go`**: `Sync()` now calls `r.SetNext(time.Now().Add(r.MinInterval()))` when `httpcl.Do(req)` returns an error
- **`resource_test.go`**: new test `network error backs off instead of tight-looping` — verifies `Next` is pushed forward after a connection failure

## Test plan

- [x] New test: `TestResourceErrorHandling/network_error_backs_off_instead_of_tight-looping`
- [x] Full suite: 143 tests pass