### PR TITLE
document regexp whitelist anchoring nuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,58 @@ If the values obtained from the headers fall within that range, the value from t
 used. If the value is larger than the maximum, the maximum is used. If the value is lower
 than the minimum, the minimum is used.
 
+# Whitelisting URLs
+
+By default the client allows all URLs. If you store resources whose URLs come from
+untrusted sources, you should restrict what can be fetched by passing a whitelist
+via `httprc.WithWhitelist`. Several implementations are provided: `BlockAllWhitelist`,
+`InsecureWhitelist` (allow all), `MapWhitelist` (exact string match), and
+`RegexpWhitelist`.
+
+## A note on `RegexpWhitelist` patterns
+
+`RegexpWhitelist` matches each URL with `(*regexp.Regexp).MatchString`, which returns
+true when the pattern matches **any substring** of the URL. Patterns are **not**
+anchored for you, so a naive pattern can allow far more than you intend.
+
+Consider the difference between these two patterns:
+
+```go
+// BAD: unanchored, dots unescaped
+regexp.MustCompile(`http://example.com`)
+
+// GOOD: anchored at the start, dots escaped, host terminated with `/`
+regexp.MustCompile(`^https://example\.com/`)
+```
+
+The unanchored `http://example.com` pattern will happily allow URLs such as:
+
+- `http://example.com.attacker.com/evil` — the real host is `attacker.com`; the
+  pattern only required `example.com` to appear *somewhere*, and without a trailing
+  `/` it does not stop at the end of the host.
+- `http://attacker.com/?redirect=http://example.com` — the pattern appears inside
+  the query string, so the match succeeds even though the host is `attacker.com`.
+- `httpsX//exampleYcom` — `.` is the regular-expression "any character"
+  metacharacter, so the dots match more than literal dots.
+
+To pin a pattern to a specific origin:
+
+1. **Anchor the start** with `^` so the match must begin at the start of the URL.
+2. **Escape the dots** (`\.`) so they only match a literal `.`.
+3. **Terminate the host** with `/` so `example.com` cannot be extended into
+   `example.com.attacker.com`.
+
+A couple of edge cases to keep in mind:
+
+- Requiring the trailing `/` means the bare origin `https://example.com` (no path)
+  will not match. Add a second pattern such as `^https://example\.com$` if you need
+  to allow it.
+- If your URLs may include a port, allow for it explicitly, e.g.
+  `^https://example\.com(:\d+)?/`.
+
+See `ExampleRegexpWhitelist` in `whitelist_example_test.go` for a runnable
+demonstration of the difference between anchored and unanchored patterns.
+
 # SYNOPSIS
 
 <!-- INCLUDE(client_example_test.go) -->

--- a/whitelist.go
+++ b/whitelist.go
@@ -49,6 +49,29 @@ func (InsecureWhitelist) IsAllowed(_ string) bool { return true }
 // RegexpWhitelist is a jwk.Whitelist object comprised of a list of *regexp.Regexp
 // objects. All entries in the list are tried until one matches. If none of the
 // *regexp.Regexp objects match, then the URL is deemed unallowed.
+//
+// Matching is performed using (*regexp.Regexp).MatchString, which succeeds when
+// the pattern matches ANY substring of the URL — it is NOT anchored automatically.
+// This has important security implications: a pattern like `http://example.com`
+// will match URLs you almost certainly did not intend to allow, such as
+// `http://example.com.attacker.com/` (the host is actually attacker.com) or
+// `http://attacker.com/?u=http://example.com` (the pattern appears in the query).
+//
+// To restrict to a specific origin, anchor the pattern at the start with `^`,
+// escape the dots in the host (`.` is the "any character" metacharacter in a
+// regular expression), and terminate the host with a `/` so that it cannot be
+// extended into a subdomain:
+//
+//	// GOOD: only matches the example.com origin and its paths
+//	regexp.MustCompile(`^https://example\.com/`)
+//
+//	// BAD: also matches example.com.attacker.com, attacker.com/?x=http://example.com, httpsX//exampleYcom, ...
+//	regexp.MustCompile(`http://example.com`)
+//
+// Note that requiring a trailing `/` means the bare origin URL `https://example.com`
+// (no path) will not match; register an additional pattern such as
+// `^https://example\.com$` if you need to allow it. Likewise, account for an
+// optional port (e.g. `^https://example\.com(:\d+)?/`) if your URLs may include one.
 type RegexpWhitelist struct {
 	mu       sync.RWMutex
 	patterns []*regexp.Regexp

--- a/whitelist_example_test.go
+++ b/whitelist_example_test.go
@@ -1,0 +1,37 @@
+package httprc_test
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/lestrrat-go/httprc/v3"
+)
+
+// ExampleRegexpWhitelist demonstrates why RegexpWhitelist patterns should be
+// anchored. RegexpWhitelist matches each URL with (*regexp.Regexp).MatchString,
+// which succeeds when the pattern matches any substring of the URL. An unanchored
+// pattern such as `http://example.com` therefore allows URLs whose host is not
+// example.com at all, while an anchored pattern such as `^https://example\.com/`
+// restricts matches to the intended origin.
+func ExampleRegexpWhitelist() {
+	urls := []string{
+		"https://example.com/data",            // legitimate
+		"https://example.com.attacker.com/x",  // host is actually attacker.com
+		"https://attacker.com/?u=example.com", // pattern appears in the query
+	}
+
+	// BAD: unanchored, dots unescaped. Matches example.com anywhere in the URL.
+	bad := httprc.NewRegexpWhitelist().Add(regexp.MustCompile(`example.com`))
+
+	// GOOD: anchored at the start, dots escaped, host terminated with `/`.
+	good := httprc.NewRegexpWhitelist().Add(regexp.MustCompile(`^https://example\.com/`))
+
+	for _, u := range urls {
+		fmt.Printf("%-37s bad=%-5t good=%t\n", u, bad.IsAllowed(u), good.IsAllowed(u))
+	}
+
+	// OUTPUT:
+	// https://example.com/data              bad=true  good=true
+	// https://example.com.attacker.com/x    bad=true  good=false
+	// https://attacker.com/?u=example.com   bad=true  good=false
+}


### PR DESCRIPTION
- Document that `RegexpWhitelist` uses unanchored `MatchString`, so naive patterns over-match (godoc + README section)
- Recommend anchored patterns (`^https://example\.com/`), covering port and bare-origin edge cases
- Add runnable `ExampleRegexpWhitelist` contrasting anchored vs unanchored matching
