### PR TITLE
fix lint: use stable Go, pin golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,10 @@ jobs:
       - name: Install Go stable version
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: stable
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
       - name: Run go vet
         run: |
           go vet ./...


### PR DESCRIPTION
- Install a modern Go toolchain (`go-version: stable`) for the lint job instead of `go-version-file: go.mod`, which pinned it to Go 1.17
- Root cause of the exit-3 lint failure: modern golangci-lint runs `go list -buildvcs=...`, a flag absent in Go 1.17, so `go list` fails. The step was even named "Install Go stable version" but installed 1.17. (Module stays Go 1.17; golangci-lint still analyzes for 1.17 via go.mod.)
- Also pin `golangci-lint` to `v2.11.4` (matches jwx) for deterministic CI
- `golangci-lint run ./...` is clean on v2 (0 issues)
- Once merged, rebasing #117 (`@dependabot rebase`) turns its lint green
