### PR TITLE
de-flake TestCache with eventually waits

### DIFF
--- a/httprc_test.go
+++ b/httprc_test.go
@@ -69,17 +69,21 @@ func TestCache(t *testing.T) {
 	require.Equal(t, 1, called, `there should only be one fetch request`)
 	muCalled.Unlock()
 
-	time.Sleep(4 * time.Second)
+	// Wait for a background refresh to fire once the entry expires, instead
+	// of racing a fixed sleep against the (second-rounded) refresh schedule.
+	require.Eventually(t, func() bool {
+		muCalled.Lock()
+		defer muCalled.Unlock()
+		return called >= 2
+	}, 10*time.Second, 100*time.Millisecond, `a background refresh should fire after the entry expires`)
+
+	// Gets continue to succeed and are served from the cache.
 	for i := 0; i < 3; i++ {
 		_, err := c.Get(ctx, srv.URL)
 		require.NoError(t, err, `c.Get should succeed`)
 	}
 
-	muCalled.Lock()
-	require.Equal(t, 2, called, `there should only be one fetch request`)
-	muCalled.Unlock()
-
-	require.Empty(t, errSink.errors)
+	require.Empty(t, errSink.getErrors())
 
 	c.Register(srv.URL,
 		httprc.WithHTTPClient(srv.Client()),
@@ -89,9 +93,12 @@ func TestCache(t *testing.T) {
 		})),
 	)
 
+	// The synchronous Get returns the transform error to the caller; the
+	// error sink is only fed by background refreshes. Wait for one to fire
+	// rather than racing a fixed sleep against the refresh schedule.
 	_, _ = c.Get(ctx, srv.URL)
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		return len(errSink.getErrors()) > 0
+	}, 10*time.Second, 100*time.Millisecond, `error sink should receive a background refresh error`)
 	cancel()
-
-	require.NotEmpty(t, errSink.getErrors())
 }


### PR DESCRIPTION
- `TestCache` raced fixed `time.Sleep`s against the background refresh schedule, so it intermittently failed in CI (seen on #126: `errSink` empty at line 96; also `called` == 3 vs expected 2 at line 79)
- Root cause: the error sink is fed only by background refreshes, and refresh fire times are rounded to the second, so the number of refreshes within a fixed sleep is non-deterministic
- Replace the sleeps + exact-count asserts with `require.Eventually` waits that capture the real intent: a refresh fires after expiry (`called >= 2`) and the error sink receives a transform error
- Also route the post-refresh empty check through `getErrors()` (locked) instead of touching the unguarded slice field
- Verified: 12/12 plain + 5/5 `-race` runs of `TestCache`; full `go test -race ./...` green
