### PR TITLE
fix lint: pin golangci-lint, use atomic.Int64

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
       - name: Run go vet
         run: |
           go vet ./...

--- a/integration_test.go
+++ b/integration_test.go
@@ -132,9 +132,9 @@ func TestConcurrentResourceAccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var requestCount int64
+	var requestCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		count := atomic.AddInt64(&requestCount, 1)
+		count := requestCount.Add(1)
 		json.NewEncoder(w).Encode(map[string]int64{"count": count})
 	}))
 	defer srv.Close()


### PR DESCRIPTION
v3 equivalent of #126. (No #127 equivalent needed — v3 has no `TestCache`; its suite is stable across 12 `-race` runs.)

- Pin `golangci-lint` to `v2.11.4` (matches v2/jwx) so CI doesn't track "latest". v3 lint has been red since 2026-03-30 because a newer golangci-lint under `default: all` surfaced new findings
- v3's Go toolchain is already modern (`go 1.23` / `1.24.4`), so the v2 `-buildvcs` fix (`go-version: stable`) is not needed here
- The pin clears 19 `goconst` findings; the one remaining `modernize` finding is fixed by switching `requestCount` to `atomic.Int64` in integration_test.go
- Verified: `golangci-lint run ./...` clean at v2.11.4; `go test -race ./...` green
