### PR TITLE
back off on fetch failure instead of tight-looping

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -232,6 +232,10 @@ func (r *ResourceBase[T]) Sync(ctx context.Context) error {
 	traceSink.Put(ctx, fmt.Sprintf("httprc.Resource.Sync: fetching %q", r.u))
 	res, err := httpcl.Do(req)
 	if err != nil {
+		// Schedule retry after MinInterval so that connection failures
+		// don't cause a tight retry loop (the resource's Next stays at
+		// epoch if we don't update it here).
+		r.SetNext(time.Now().Add(r.MinInterval()))
 		return fmt.Errorf(`httprc.Resource.Sync: failed to execute HTTP request: %w`, err)
 	}
 	defer res.Body.Close()

--- a/resource_test.go
+++ b/resource_test.go
@@ -263,18 +263,23 @@ func TestResourceErrorHandling(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		// Next starts at epoch (time.Unix(0, 0)) so the resource is fetched
+		// immediately; capture the time before Add so we can tell once a
+		// failed fetch has pushed Next forward.
+		before := time.Now()
 		require.NoError(t, ctrl.Add(ctx, resource, httprc.WithWaitReady(false)))
 
-		// Wait for the first fetch attempt to fail
-		readyCtx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
-		require.Error(t, resource.Ready(readyCtx))
+		// Wait for the first failed fetch to move Next off its initial epoch
+		// value. Polling avoids racing the fetch against a fixed sleep.
+		require.Eventually(t, func() bool {
+			return resource.Next().After(before)
+		}, 5*time.Second, 50*time.Millisecond,
+			"after a connection failure, Next should be pushed into the future, not left at epoch")
 
-		// After a failed fetch, Next should be pushed forward by at least
-		// MinInterval, not stuck at epoch (which caused a tight retry loop).
-		next := resource.Next()
-		require.True(t, next.After(time.Now().Add(minInterval/2)),
-			"after connection failure, Next should be at least minInterval/2 in the future, got %v", next)
+		// The backoff should be on the order of MinInterval, which is what
+		// prevents the tight retry loop.
+		require.GreaterOrEqual(t, resource.Next().Sub(before), minInterval/2,
+			"after a connection failure, Next should be backed off by ~MinInterval")
 	})
 
 	t.Run("context cancellation", func(t *testing.T) {

--- a/resource_test.go
+++ b/resource_test.go
@@ -254,6 +254,29 @@ func TestResourceErrorHandling(t *testing.T) {
 		require.Error(t, resource.Ready(readyCtx), "network error resource should not become ready")
 	})
 
+	t.Run("network error backs off instead of tight-looping", func(t *testing.T) {
+		minInterval := 2 * time.Second
+		resource, err := httprc.NewResource[[]byte](
+			"http://127.0.0.1:1/unreachable",
+			httprc.BytesTransformer(),
+			httprc.WithMinInterval(minInterval),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, ctrl.Add(ctx, resource, httprc.WithWaitReady(false)))
+
+		// Wait for the first fetch attempt to fail
+		readyCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		require.Error(t, resource.Ready(readyCtx))
+
+		// After a failed fetch, Next should be pushed forward by at least
+		// MinInterval, not stuck at epoch (which caused a tight retry loop).
+		next := resource.Next()
+		require.True(t, next.After(time.Now().Add(minInterval/2)),
+			"after connection failure, Next should be at least minInterval/2 in the future, got %v", next)
+	})
+
 	t.Run("context cancellation", func(t *testing.T) {
 		slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(2 * time.Second) // Slow response


### PR DESCRIPTION
Supersedes #120 (fixes #119). Cherry-picks @klaidliadon's production change and fixes the accompanying test.

- `resource.go` (cherry-picked, authorship preserved): on the `httpcl.Do` error path, set `Next = now + MinInterval` so connection failures back off instead of being re-dispatched every ~1s. Consistent with the success/non-200 paths, which already set `Next`.
- `resource_test.go`: the original test asserted `next.After(now + minInterval/2)` after a 1s `Ready` wait — at `minInterval=2s` the margin is exactly zero, so it failed ~70-80% of the time. Reworked to capture `before` pre-Add, wait (via `require.Eventually`) for the failed fetch to push `Next` off its initial epoch value, then assert the backoff is `>= minInterval/2`.
- Verified: target test 15/15; `go test -race ./...` green; lint clean (golangci-lint v2.11.4).

Note: this is a fixed-interval backoff; exponential backoff (#12) remains a separate enhancement. The context-cancellation half of #119 is already handled in v3 via `http.NewRequestWithContext`.
